### PR TITLE
Fix: README.md crontab example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ watch_folders = ['isos', 'news', 'videos']
 ### crontab
 Run the download script on an interval so you don't miss out on any of your files
 ```crontab
-*/10 * * * * putio_download --config ~/myconfig.ini >> ~/putio.log 2>&1
+*/10 * * * * putio-download --config ~/myconfig.ini >> ~/putio.log 2>&1
 ```

--- a/putio_downloader/putio_aria2c_downloader.py
+++ b/putio_downloader/putio_aria2c_downloader.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import time
 import xmlrpc.client
+import shutil
 
 import click
 import putiopy
@@ -110,7 +111,7 @@ class PutioAria2cDownloader():
                     _file.delete(True)
                     download_path = '/'.join([download_dir, path, _file.name])
                     destination_path = '/'.join([self.post_process_dir, path, _file.name])
-                    os.rename(download_path, destination_path)
+                    shutil.move(download_path, destination_path)
                 else:
                     click.echo(
                         'File {} didn\'t download successfully with aria'.format(_file.name)


### PR DESCRIPTION
Fix crontab example
Fixes issue #4 

Also add a feature, enabling cross-disk copying (not using os.rename)